### PR TITLE
Import github-settings repo and add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ojhermann-org

--- a/imports.tf
+++ b/imports.tf
@@ -4,3 +4,8 @@
 #   2. Add matching module/resource to repositories.tf or organization.tf
 #   3. Run tofu plan to verify, then tofu apply (import block must still be present)
 #   4. Remove import blocks after successful apply
+
+import {
+  to = module.github_settings.github_repository.repo
+  id = "github-settings"
+}

--- a/modules/standard_repo/main.tf
+++ b/modules/standard_repo/main.tf
@@ -40,6 +40,8 @@ resource "github_repository" "repo" {
 }
 
 resource "github_repository_file" "codeowners" {
+  count = var.create_codeowners ? 1 : 0
+
   repository          = github_repository.repo.name
   branch              = "main"
   file                = "CODEOWNERS"

--- a/modules/standard_repo/variables.tf
+++ b/modules/standard_repo/variables.tf
@@ -14,3 +14,9 @@ variable "homepage_url" {
   type        = string
   default     = ""
 }
+
+variable "create_codeowners" {
+  description = "Whether to manage the CODEOWNERS file via tofu. Set to false for repos where the file is committed directly (e.g. the IaC repo itself, which requires a PR to push to main)."
+  type        = bool
+  default     = true
+}

--- a/repositories.tf
+++ b/repositories.tf
@@ -13,3 +13,11 @@ module "home_manager" {
   source = "./modules/standard_repo"
   name   = "home-manager"
 }
+
+module "github_settings" {
+  source      = "./modules/standard_repo"
+  name        = "github-settings"
+  description = "ojhermann's GitHub account settings managed as IaC"
+
+  create_codeowners = false # CODEOWNERS is committed directly in the repo via PR
+}


### PR DESCRIPTION
## Summary

- Imports `ojhermann-org/github-settings` into tofu state via the `standard_repo` module (enables `delete_branch_on_merge` and other standard settings)
- Adds `CODEOWNERS` file directly in the repo (committed via PR since the org ruleset prevents direct pushes to main)
- Adds `create_codeowners` variable to `standard_repo` module (default `true`) to handle repos where tofu cannot write directly to main

## Test plan

- [x] `tofu plan` shows no changes after import
- [x] `tofu validate` passes
- [x] CODEOWNERS present in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)