### PR TITLE
Enable security defaults for new org repositories

### DIFF
--- a/organization.tf
+++ b/organization.tf
@@ -13,11 +13,11 @@ resource "github_organization_settings" "settings" {
   members_can_fork_private_repositories                        = false
   web_commit_signoff_required                                  = false
   advanced_security_enabled_for_new_repositories               = false
-  dependabot_alerts_enabled_for_new_repositories               = false
-  dependabot_security_updates_enabled_for_new_repositories     = false
-  dependency_graph_enabled_for_new_repositories                = false
-  secret_scanning_enabled_for_new_repositories                 = false
-  secret_scanning_push_protection_enabled_for_new_repositories = false
+  dependabot_alerts_enabled_for_new_repositories               = true
+  dependabot_security_updates_enabled_for_new_repositories     = true
+  dependency_graph_enabled_for_new_repositories                = true
+  secret_scanning_enabled_for_new_repositories                 = true
+  secret_scanning_push_protection_enabled_for_new_repositories = true
 }
 
 resource "github_organization_ruleset" "default_branch" {


### PR DESCRIPTION
## Summary

- Enables dependabot alerts, dependabot security updates, dependency graph, secret scanning, and secret scanning push protection at the org level for all new repositories
- Existing managed repos already have these set explicitly via the `standard_repo` module — this closes the gap for any repos not yet under IaC management

## Test plan

- [x] `tofu plan` shows exactly the 5 expected changes, no destroys
- [x] `tofu apply` succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)