### PR TITLE
Add CI required status checks ruleset for home-manager

### DIFF
--- a/modules/standard_repo/main.tf
+++ b/modules/standard_repo/main.tf
@@ -39,6 +39,33 @@ resource "github_repository" "repo" {
   }
 }
 
+resource "github_repository_ruleset" "ci_checks" {
+  count = length(var.required_status_checks) > 0 ? 1 : 0
+
+  name        = "ci-checks"
+  repository  = github_repository.repo.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    required_status_checks {
+      dynamic "required_check" {
+        for_each = var.required_status_checks
+        content {
+          context = required_check.value
+        }
+      }
+    }
+  }
+}
+
 resource "github_repository_file" "codeowners" {
   count = var.create_codeowners ? 1 : 0
 

--- a/modules/standard_repo/variables.tf
+++ b/modules/standard_repo/variables.tf
@@ -15,6 +15,12 @@ variable "homepage_url" {
   default     = ""
 }
 
+variable "required_status_checks" {
+  description = "List of CI check names that must pass before merging to the default branch. Empty list disables this ruleset."
+  type        = list(string)
+  default     = []
+}
+
 variable "create_codeowners" {
   description = "Whether to manage the CODEOWNERS file via tofu. Set to false for repos where the file is committed directly (e.g. the IaC repo itself, which requires a PR to push to main)."
   type        = bool

--- a/repositories.tf
+++ b/repositories.tf
@@ -12,6 +12,8 @@ module "configuration_apple_os" {
 module "home_manager" {
   source = "./modules/standard_repo"
   name   = "home-manager"
+
+  required_status_checks = ["lint", "build"] # require CI to pass before merging
 }
 
 module "github_settings" {


### PR DESCRIPTION
## Summary

- Adds a `required_status_checks` variable to the `standard_repo` module (default: `[]`, no ruleset created)
- When non-empty, creates a `github_repository_ruleset` that blocks merges to the default branch until all listed checks pass
- Enables it for `home-manager` with `["lint", "build"]`

## Test plan

- [ ] `tofu plan` shows one new resource: `module.home_manager.github_repository_ruleset.ci_checks[0]`
- [ ] No changes planned for other repos (ruleset is opt-in via the variable)
- [ ] `tofu apply` creates the ruleset in GitHub
- [ ] Verify in GitHub UI: home-manager repo → Settings → Rules shows `ci-checks` requiring `lint` and `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)