### PR TITLE
Add tflint pre-commit hook

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,4 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}

--- a/modules/standard_repo/versions.tf
+++ b/modules/standard_repo/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/prek.toml
+++ b/prek.toml
@@ -14,4 +14,5 @@ repo = "local"
 hooks = [
   {id = "tofu-fmt",      name = "tofu fmt",      entry = "tofu fmt",      language = "system", files = "\\.tf$", pass_filenames = false},
   {id = "tofu-validate", name = "tofu validate",  entry = "tofu validate", language = "system", pass_filenames = false},
+  {id = "tflint",        name = "tflint",         entry = "tflint --recursive", language = "system", pass_filenames = false},
 ]


### PR DESCRIPTION
## Summary

- Adds `.tflint.hcl` enabling the bundled `terraform` ruleset with the recommended preset
- Adds `modules/standard_repo/versions.tf` to fix the two lint warnings (`terraform_required_version` and `terraform_required_providers`)
- Adds `tflint --recursive` hook to `prek.toml`

Closes #2

## Test plan

- [ ] `tflint --recursive` runs clean locally
- [ ] Pre-commit hook fires on `.tf` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)