### PR TITLE
fix: use personal account in CODEOWNERS template

### DIFF
--- a/modules/standard_repo/main.tf
+++ b/modules/standard_repo/main.tf
@@ -68,7 +68,7 @@ resource "github_repository_file" "codeowners" {
   repository          = github_repository.repo.name
   branch              = "main"
   file                = "CODEOWNERS"
-  content             = "* @ojhermann-org\n"
+  content             = "* @ojhermann\n"
   commit_message      = "Add CODEOWNERS"
   overwrite_on_create = true
 


### PR DESCRIPTION
## Summary

- CODEOWNERS was using `@ojhermann-org` (an organization), which is not valid — GitHub only accepts individual users or `@org/team-name`
- Updated the `standard_repo` module to use `@ojhermann`
- Fixes the warning across all 8 repos that use this module

## tofu plan

8 in-place updates (CODEOWNERS content only), 0 adds, 0 destroys.

## After merging

Please run `tofu apply` (can be triggered via the GitHub Actions UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)