### PR TITLE
feat: add admins team with ojhermann as maintainer

### DIFF
--- a/teams.tf
+++ b/teams.tf
@@ -1,0 +1,11 @@
+resource "github_team" "admins" {
+  name        = "admins"
+  description = "Organization administrators"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "admins_ojhermann" {
+  team_id  = github_team.admins.id
+  username = "ojhermann"
+  role     = "maintainer"
+}


### PR DESCRIPTION
## Summary
- Create `admins` team at the org level
- Add `ojhermann` as team maintainer

This team will be used as the reviewer for GitHub Actions environments (starting with fred's `integration` environment in ojhermann-org/fred#12).

## Test plan
- [x] CI plan job shows 2 new resources (`github_team`, `github_team_membership`)
- [x] After apply, verify team exists at https://github.com/orgs/ojhermann-org/teams/admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)