### PR TITLE
chore: remove flake-uv-template repository

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -1,8 +1,3 @@
-module "flake_uv_template" {
-  source = "./modules/standard_repo"
-  name   = "flake-uv-template"
-}
-
 module "configuration_apple_os" {
   source      = "./modules/standard_repo"
   name        = "configuration_apple_os"


### PR DESCRIPTION
## Summary
- Removes the `flake_uv_template` module from `repositories.tf`
- After merge + apply, the `flake-uv-template` repo will be destroyed on GitHub (the `standard_repo` module sets `archive_on_destroy = false`)

## Plan
`tofu plan` shows `0 to add, 0 to change, 3 to destroy` — the `github_repository`, its `branch-naming` ruleset, and the CODEOWNERS file, all under `module.flake_uv_template`.

## Test plan
- [ ] CI `plan` job confirms only the three `module.flake_uv_template` resources are destroyed
- [ ] After merge, run `tofu apply` via the manual workflow
- [ ] Confirm `flake-uv-template` no longer appears under ojhermann-org

🤖 Generated with [Claude Code](https://claude.com/claude-code)