### PR TITLE
feat: add license_template to standard_repo module

### DIFF
--- a/modules/standard_repo/main.tf
+++ b/modules/standard_repo/main.tf
@@ -28,6 +28,8 @@ resource "github_repository" "repo" {
   vulnerability_alerts        = true
   web_commit_signoff_required = false
 
+  license_template = var.license_template
+
   dynamic "security_and_analysis" {
     for_each = var.visibility == "public" ? [1] : []
     content {
@@ -38,6 +40,10 @@ resource "github_repository" "repo" {
         status = "enabled"
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [license_template]
   }
 }
 

--- a/modules/standard_repo/variables.tf
+++ b/modules/standard_repo/variables.tf
@@ -31,3 +31,9 @@ variable "visibility" {
     error_message = "visibility must be 'public' or 'private'."
   }
 }
+
+variable "license_template" {
+  description = "GitHub license template keyword used when the repository is created (e.g. 'apache-2.0', 'mit'). Only applied on initial creation; ignored on subsequent runs so existing repos do not drift."
+  type        = string
+  default     = "apache-2.0"
+}


### PR DESCRIPTION
## Summary
- Adds a `license_template` variable to the `standard_repo` module, default `"apache-2.0"`, so newly created repos ship with a LICENSE file.
- Wires it into `github_repository.repo` and adds `lifecycle.ignore_changes = [license_template]` so existing repos (created without a template) do not show perpetual drift.
- Enables the upcoming `/new-repo` skill to request a license per-repo via the module input.

## Test plan
- [x] `tofu init` succeeds
- [x] `tofu validate` passes
- [x] `tofu plan` reports `No changes` against current infrastructure (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)