### PR TITLE
feat: add topics input to standard_repo

### DIFF
--- a/modules/standard_repo/main.tf
+++ b/modules/standard_repo/main.tf
@@ -24,7 +24,7 @@ resource "github_repository" "repo" {
   squash_merge_commit_message = "COMMIT_MESSAGES"
   squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
 
-  topics                      = []
+  topics                      = var.topics
   vulnerability_alerts        = true
   web_commit_signoff_required = false
 

--- a/modules/standard_repo/variables.tf
+++ b/modules/standard_repo/variables.tf
@@ -37,3 +37,9 @@ variable "license_template" {
   type        = string
   default     = "apache-2.0"
 }
+
+variable "topics" {
+  description = "GitHub topics to attach to the repository, used for discoverability."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- Adds a `topics` `list(string)` input to the `standard_repo` module (default `[]`) and wires it into `github_repository.repo`.
- Enables the upcoming `/new-repo` skill update to prompt for and set GitHub topics per-repo for discoverability.

## Test plan
- [x] `tofu init` succeeds
- [x] `tofu validate` passes
- [x] `tofu plan` reports `No changes` against current infrastructure (every existing repo already had `topics = []`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)