### PR TITLE
feat: define FLAKE_BOT_APP_ID/PRIVATE_KEY as selected org secrets via bot_org_secrets module

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -11,6 +11,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_bot_app_id: ${{ secrets.BOT_APP_ID }}
+      TF_VAR_bot_app_private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
       - uses: opentofu/setup-opentofu@v2

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -11,8 +11,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      TF_VAR_bot_app_id: ${{ secrets.BOT_APP_ID }}
-      TF_VAR_bot_app_private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+      TF_VAR_flake_bot_app_id: ${{ secrets.FLAKE_BOT_APP_ID }}
+      TF_VAR_flake_bot_app_private_key: ${{ secrets.FLAKE_BOT_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
       - uses: opentofu/setup-opentofu@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_bot_app_id: ${{ secrets.BOT_APP_ID }}
+      TF_VAR_bot_app_private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
       - uses: opentofu/setup-opentofu@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      TF_VAR_bot_app_id: ${{ secrets.BOT_APP_ID }}
-      TF_VAR_bot_app_private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+      TF_VAR_flake_bot_app_id: ${{ secrets.FLAKE_BOT_APP_ID }}
+      TF_VAR_flake_bot_app_private_key: ${{ secrets.FLAKE_BOT_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
       - uses: opentofu/setup-opentofu@v2

--- a/modules/bot_org_secrets/main.tf
+++ b/modules/bot_org_secrets/main.tf
@@ -1,0 +1,21 @@
+resource "github_actions_organization_secret" "app_id" {
+  secret_name     = "${var.secret_prefix}_APP_ID"
+  visibility      = "selected"
+  plaintext_value = var.app_id
+}
+
+resource "github_actions_organization_secret_repositories" "app_id" {
+  secret_name             = github_actions_organization_secret.app_id.secret_name
+  selected_repository_ids = var.selected_repository_ids
+}
+
+resource "github_actions_organization_secret" "app_private_key" {
+  secret_name     = "${var.secret_prefix}_APP_PRIVATE_KEY"
+  visibility      = "selected"
+  plaintext_value = var.app_private_key
+}
+
+resource "github_actions_organization_secret_repositories" "app_private_key" {
+  secret_name             = github_actions_organization_secret.app_private_key.secret_name
+  selected_repository_ids = var.selected_repository_ids
+}

--- a/modules/bot_org_secrets/variables.tf
+++ b/modules/bot_org_secrets/variables.tf
@@ -1,0 +1,21 @@
+variable "secret_prefix" {
+  type        = string
+  description = "Prefix used to name the org secrets (e.g. \"FLAKE_BOT\" produces FLAKE_BOT_APP_ID and FLAKE_BOT_APP_PRIVATE_KEY)."
+}
+
+variable "app_id" {
+  type        = string
+  description = "GitHub App ID for this bot."
+  sensitive   = true
+}
+
+variable "app_private_key" {
+  type        = string
+  description = "GitHub App private key (PEM) for this bot."
+  sensitive   = true
+}
+
+variable "selected_repository_ids" {
+  type        = list(number)
+  description = "Numeric repo IDs that can read this bot's org secrets."
+}

--- a/modules/bot_org_secrets/versions.tf
+++ b/modules/bot_org_secrets/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/modules/standard_repo/outputs.tf
+++ b/modules/standard_repo/outputs.tf
@@ -1,0 +1,4 @@
+output "repo_id" {
+  description = "Numeric repository database ID, used for org-secret visibility lists."
+  value       = github_repository.repo.repo_id
+}

--- a/org_secrets.tf
+++ b/org_secrets.tf
@@ -1,0 +1,39 @@
+variable "bot_app_id" {
+  type        = string
+  description = "GitHub App ID for the shared automation bot (e.g. flake-bot). Sourced from TF_VAR_bot_app_id."
+  sensitive   = true
+}
+
+variable "bot_app_private_key" {
+  type        = string
+  description = "GitHub App private key (PEM) for the shared automation bot. Sourced from TF_VAR_bot_app_private_key."
+  sensitive   = true
+}
+
+locals {
+  bot_secret_repo_ids = [
+    module.fred.repo_id,
+  ]
+}
+
+resource "github_actions_organization_secret" "bot_app_id" {
+  secret_name     = "BOT_APP_ID"
+  visibility      = "selected"
+  plaintext_value = var.bot_app_id
+}
+
+resource "github_actions_organization_secret_repositories" "bot_app_id" {
+  secret_name             = github_actions_organization_secret.bot_app_id.secret_name
+  selected_repository_ids = local.bot_secret_repo_ids
+}
+
+resource "github_actions_organization_secret" "bot_app_private_key" {
+  secret_name     = "BOT_APP_PRIVATE_KEY"
+  visibility      = "selected"
+  plaintext_value = var.bot_app_private_key
+}
+
+resource "github_actions_organization_secret_repositories" "bot_app_private_key" {
+  secret_name             = github_actions_organization_secret.bot_app_private_key.secret_name
+  selected_repository_ids = local.bot_secret_repo_ids
+}

--- a/org_secrets.tf
+++ b/org_secrets.tf
@@ -1,39 +1,21 @@
-variable "bot_app_id" {
+variable "flake_bot_app_id" {
   type        = string
-  description = "GitHub App ID for the shared automation bot (e.g. flake-bot). Sourced from TF_VAR_bot_app_id."
+  description = "GitHub App ID for the flake-bot (Nix flake.lock updates). Sourced from TF_VAR_flake_bot_app_id."
   sensitive   = true
 }
 
-variable "bot_app_private_key" {
+variable "flake_bot_app_private_key" {
   type        = string
-  description = "GitHub App private key (PEM) for the shared automation bot. Sourced from TF_VAR_bot_app_private_key."
+  description = "GitHub App private key (PEM) for the flake-bot. Sourced from TF_VAR_flake_bot_app_private_key."
   sensitive   = true
 }
 
-locals {
-  bot_secret_repo_ids = [
+module "flake_bot_secrets" {
+  source          = "./modules/bot_org_secrets"
+  secret_prefix   = "FLAKE_BOT"
+  app_id          = var.flake_bot_app_id
+  app_private_key = var.flake_bot_app_private_key
+  selected_repository_ids = [
     module.fred.repo_id,
   ]
-}
-
-resource "github_actions_organization_secret" "bot_app_id" {
-  secret_name     = "BOT_APP_ID"
-  visibility      = "selected"
-  plaintext_value = var.bot_app_id
-}
-
-resource "github_actions_organization_secret_repositories" "bot_app_id" {
-  secret_name             = github_actions_organization_secret.bot_app_id.secret_name
-  selected_repository_ids = local.bot_secret_repo_ids
-}
-
-resource "github_actions_organization_secret" "bot_app_private_key" {
-  secret_name     = "BOT_APP_PRIVATE_KEY"
-  visibility      = "selected"
-  plaintext_value = var.bot_app_private_key
-}
-
-resource "github_actions_organization_secret_repositories" "bot_app_private_key" {
-  secret_name             = github_actions_organization_secret.bot_app_private_key.secret_name
-  selected_repository_ids = local.bot_secret_repo_ids
 }


### PR DESCRIPTION
## Summary
- New `modules/bot_org_secrets` module: takes a `secret_prefix` (e.g. `FLAKE_BOT`), app credentials, and a repo visibility list, and creates the two org secrets (`<prefix>_APP_ID`, `<prefix>_APP_PRIVATE_KEY`) plus matching `github_actions_organization_secret_repositories` resources.
- `org_secrets.tf` defines `flake_bot_app_id` / `flake_bot_app_private_key` variables (sensitive) and a single `module "flake_bot_secrets"` call. Initial visibility list: `module.fred.repo_id` only.
- `standard_repo` module now exposes `repo_id` so `org_secrets.tf` can reference repos symbolically rather than via hardcoded numeric IDs.
- CI plan and apply workflows pass `TF_VAR_flake_bot_app_id` / `TF_VAR_flake_bot_app_private_key` from new repo Actions secrets `FLAKE_BOT_APP_ID` / `FLAKE_BOT_APP_PRIVATE_KEY`.

## Why per-purpose (not one shared bot)
Each bot does different things — flake updates, releases, etc. — and their requirements may diverge over time. A separate App per purpose lets each one have its own permissions, install scope, key rotation cadence, and audit trail. Adding a second bot is a few lines: define two more variables and another `module "<name>_secrets"` block.

## Manual steps required before this can be applied
1. **Create the GitHub App** under `ojhermann-org` (Settings → Developer settings → GitHub Apps). Name: `flake-bot` (or similar). Permissions: Contents R/W, Pull requests R/W, Metadata R. No webhook, no events.
2. **Generate a private key** (PEM) for the app.
3. **Install the app** on the `fred` repo only.
4. **Add the repo Actions secrets** here in `github-settings`:
   - `FLAKE_BOT_APP_ID` = numeric app ID
   - `FLAKE_BOT_APP_PRIVATE_KEY` = full PEM contents
5. **Run the Apply workflow** (Actions → Apply → Run workflow). Creates the org secrets and grants `fred` access.

## Test plan
- [ ] CI plan passes (TF_VAR values flow from repo secrets)
- [ ] Apply creates `FLAKE_BOT_APP_ID` and `FLAKE_BOT_APP_PRIVATE_KEY` org secrets, `selected` visibility scoped to `fred`
- [ ] Verify `fred`'s `update-flake-lock` workflow run can read both secrets and successfully open a PR that triggers CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)